### PR TITLE
Assembly-specific code moves inside [PARTIALLY]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 1.1.0 2023-30-06
+- [GRD-645](https://jira.oicr.on.ca/browse/GRD-645) Assembly-specific settings moved inside wdl file
 # 1.0.3 2022-04-05
 - adding MiSeq alias for handling smaller datasets
 # 1.0.2 2021-06-24

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Parameter|Value|Description
 ---|---|---
 `fastqR1`|File|fastq file for read 1
 `fastqR2`|File|fastq file for read 2
-`bwaMem.runBwaMem_bwaRef`|String|The reference genome to align the sample with by BWA
-`bwaMem.runBwaMem_modules`|String|Required environment modules
+`reference`|String|Reference Assembly id
 `bwaMem.readGroups`|String|Complete read group header line
 `bamQC.bamQCMetrics_workflowVersion`|String|Workflow version string
 `bamQC.bamQCMetrics_refSizesBed`|String|Path to human genome BED reference with chromosome sizes

--- a/dnaSeqQC.wdl
+++ b/dnaSeqQC.wdl
@@ -3,69 +3,95 @@ version 1.0
 import "imports/pull_bwaMem.wdl" as bwaMem
 import "imports/pull_bamQC.wdl" as bamQC
 
+struct genomicResources {
+  String runBwaMem_bwaRef
+  String runBwaMem_modules
+}
+
+
 workflow dnaSeqQC {
     input {
         File fastqR1
         File fastqR2
+        String reference
         String outputFileNamePrefix = basename(fastqR1)
     }
 
     parameter_meta {
         fastqR1: "fastq file for read 1"
         fastqR2: "fastq file for read 2"
+        reference: "Reference Assembly id"
         outputFileNamePrefix: "Optional output prefix for the output"
     }
 
+    Map[String,genomicResources] resources = {
+      "hg19": {
+        "runBwaMem_bwaRef": "$HG19_BWA_INDEX_ROOT/hg19_random.fa", 
+        "runBwaMem_modules": "samtools/1.9 bwa/0.7.12 hg19-bwa-index/0.7.12"
+      },
+      "hg38": {
+        "runBwaMem_bwaRef": "$HG38_BWA_INDEX_ROOT/hg38_random.fa",
+        "runBwaMem_modules": "samtools/1.9 bwa/0.7.12 hg38-bwa-index/0.7.12"
+      },
+      "mm10": {
+        "runBwaMem_bwaRef": "$MM10_BWA_INDEX_ROOT/mm10.fa",
+        "runBwaMem_modules": "samtools/1.9 bwa/0.7.12 mm10-bwa-index/0.7.12"
+      }
+    }
+
+
     call bwaMem.bwaMem {
-        input:
-            fastqR1 = fastqR1,
-            fastqR2 = fastqR2,
-            outputFileNamePrefix = outputFileNamePrefix
+      input:
+        fastqR1 = fastqR1,
+        fastqR2 = fastqR2,
+        outputFileNamePrefix = outputFileNamePrefix,
+        runBwaMem_bwaRef = resources[reference].runBwaMem_bwaRef,
+        runBwaMem_modules = resources[reference].runBwaMem_modules
     }
 
     call bamQC.bamQC {
-        input:
-            bamFile = bwaMem.bwaMemBam,
-            outputFileNamePrefix = outputFileNamePrefix
+      input:
+        bamFile = bwaMem.bwaMemBam,
+        outputFileNamePrefix = outputFileNamePrefix
     }
 
     meta {
-        author: "Fenglin Chen"
-        email: "g3chen@oicr.on.ca"
-        description: "Calls the bwaMem-bamQC alignment as a single step."
-        dependencies: [
-        {
-            name: "bwa/0.7.12",
-            url: "https://github.com/lh3/bwa/archive/0.7.12.tar.gz"
-        },
-        {
-            name: "samtools/1.9",
-            url: "https://github.com/samtools/samtools/archive/0.1.19.tar.gz"
-        },
-        {
-            name: "cutadapt/1.8.3",
-            url: "https://cutadapt.readthedocs.io/en/v1.8.3/"
-        },
-        {
-            name: "slicer/0.3.0",
-            url: "https://github.com/OpenGene/slicer/archive/v0.3.0.tar.gz"
-        },
-        {
-            name: "picard/2.21.2",
-            url: "https://broadinstitute.github.io/picard/command-line-overview.html"
-        },
-        {
-            name: "python/3.6",
-            url: "https://www.python.org/downloads/"
-        },
-        {
-            name: "bam-qc-metrics/0.2.5",
-            url: "https://github.com/oicr-gsi/bam-qc-metrics.git"
-        },
-        {
-            name: "mosdepth/0.2.9",
-            url: "https://github.com/brentp/mosdepth"
-        }
+      author: "Fenglin Chen"
+      email: "g3chen@oicr.on.ca"
+      description: "Calls the bwaMem-bamQC alignment as a single step."
+      dependencies: [
+      {
+        name: "bwa/0.7.12",
+        url: "https://github.com/lh3/bwa/archive/0.7.12.tar.gz"
+      },
+      {
+        name: "samtools/1.9",
+        url: "https://github.com/samtools/samtools/archive/0.1.19.tar.gz"
+      },
+      {
+        name: "cutadapt/1.8.3",
+        url: "https://cutadapt.readthedocs.io/en/v1.8.3/"
+      },
+      {
+        name: "slicer/0.3.0",
+        url: "https://github.com/OpenGene/slicer/archive/v0.3.0.tar.gz"
+      },
+      {
+        name: "picard/2.21.2",
+        url: "https://broadinstitute.github.io/picard/command-line-overview.html"
+      },
+      {
+        name: "python/3.6",
+        url: "https://www.python.org/downloads/"
+      },
+      {
+        name: "bam-qc-metrics/0.2.5",
+        url: "https://github.com/oicr-gsi/bam-qc-metrics.git"
+      },
+      {
+        name: "mosdepth/0.2.9",
+        url: "https://github.com/brentp/mosdepth"
+      }
       ]
       output_meta: {
         log: "log file for bwaMem task",

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -99,9 +99,9 @@
             "dnaSeqQC.bwaMem.numChunk": null,
             "dnaSeqQC.bwaMem.readGroups": "'@RG\\tID:1\\tLB:neat_5x_EX_hg19_golden\\tPL:illumina\\tPU:run_barcode\\tSM:neat_5x_EX_hg19_golden'",
             "dnaSeqQC.bwaMem.runBwaMem_addParam": null,
-            "dnaSeqQC.bwaMem.runBwaMem_bwaRef": "$HG19_BWA_INDEX_ROOT/hg19_random.fa",
+            "dnaSeqQC.bwaMem.runBwaMem_bwaRef": null,
             "dnaSeqQC.bwaMem.runBwaMem_jobMemory": null,
-            "dnaSeqQC.bwaMem.runBwaMem_modules": "samtools/1.9 bwa/0.7.12 hg19-bwa-index/0.7.12",
+            "dnaSeqQC.bwaMem.runBwaMem_modules": null,
             "dnaSeqQC.bwaMem.runBwaMem_threads": null,
             "dnaSeqQC.bwaMem.runBwaMem_timeout": null,
             "dnaSeqQC.bwaMem.slicerR1_jobMemory": null,
@@ -136,6 +136,7 @@
                 },
                 "type": "EXTERNAL"
             },
+            "dnaSeqQC.reference": "hg19",
             "dnaSeqQC.outputFileNamePrefix": "dnaSeqQC_test_with_downsample"
         },
         "description": "dnaSeqQC workflow test",
@@ -279,9 +280,9 @@
             "dnaSeqQC.bwaMem.numChunk": null,
             "dnaSeqQC.bwaMem.readGroups": "'@RG\\tID:1\\tLB:neat_5x_EX_hg19_golden\\tPL:illumina\\tPU:run_barcode\\tSM:neat_5x_EX_hg19_golden'",
             "dnaSeqQC.bwaMem.runBwaMem_addParam": null,
-            "dnaSeqQC.bwaMem.runBwaMem_bwaRef": "$HG19_BWA_INDEX_ROOT/hg19_random.fa",
+            "dnaSeqQC.bwaMem.runBwaMem_bwaRef": null,
             "dnaSeqQC.bwaMem.runBwaMem_jobMemory": null,
-            "dnaSeqQC.bwaMem.runBwaMem_modules": "samtools/1.9 bwa/0.7.12 hg19-bwa-index/0.7.12",
+            "dnaSeqQC.bwaMem.runBwaMem_modules": null,
             "dnaSeqQC.bwaMem.runBwaMem_threads": null,
             "dnaSeqQC.bwaMem.runBwaMem_timeout": null,
             "dnaSeqQC.bwaMem.slicerR1_jobMemory": null,
@@ -316,6 +317,7 @@
                 },
                 "type": "EXTERNAL"
             },
+            "dnaSeqQC.reference": "hg19",
             "dnaSeqQC.outputFileNamePrefix": "dnaSeqQC_test_without_downsample"
         },
         "description": "dnaSeqQC workflow test",
@@ -459,9 +461,9 @@
             "dnaSeqQC.bwaMem.numChunk": null,
             "dnaSeqQC.bwaMem.readGroups": "'@RG\\tID:200124_A00469_0077_BHNGLTDSXX-GAGACGAT-TAACCGGT_2\\tLB:CRE_0002_Pb_R_PE_409_WG\\tPL:ILLUMINA\\tPU:200124_A00469_0077_BHNGLTDSXX-GAGACGAT-TAACCGGT_2\\tSM:CRE_0002_Pb_R'",
             "dnaSeqQC.bwaMem.runBwaMem_addParam": null,
-            "dnaSeqQC.bwaMem.runBwaMem_bwaRef": "$HG19_BWA_INDEX_ROOT/hg19_random.fa",
+            "dnaSeqQC.bwaMem.runBwaMem_bwaRef": null,
             "dnaSeqQC.bwaMem.runBwaMem_jobMemory": null,
-            "dnaSeqQC.bwaMem.runBwaMem_modules": "samtools/1.9 bwa/0.7.12 hg19-bwa-index/0.7.12",
+            "dnaSeqQC.bwaMem.runBwaMem_modules": null,
             "dnaSeqQC.bwaMem.runBwaMem_threads": null,
             "dnaSeqQC.bwaMem.runBwaMem_timeout": null,
             "dnaSeqQC.bwaMem.slicerR1_jobMemory": null,
@@ -496,6 +498,7 @@
                 },
                 "type": "EXTERNAL"
             },
+            "dnaSeqQC.reference": "hg19",
             "dnaSeqQC.outputFileNamePrefix": "dnaSeqQC_test_CRE"
         },
         "description": "dnaSeqQC workflow test",
@@ -639,9 +642,9 @@
             "dnaSeqQC.bwaMem.numChunk": null,
             "dnaSeqQC.bwaMem.readGroups": "'@RG\\tID:200124_A00469_0077_BHNGLTDSXX-GAGACGAT-TAACCGGT_2\\tLB:CRE_0002_Pb_R_PE_409_WG\\tPL:ILLUMINA\\tPU:200124_A00469_0077_BHNGLTDSXX-GAGACGAT-TAACCGGT_2\\tSM:CRE_0002_Pb_R'",
             "dnaSeqQC.bwaMem.runBwaMem_addParam": null,
-            "dnaSeqQC.bwaMem.runBwaMem_bwaRef": "$HG19_BWA_INDEX_ROOT/hg19_random.fa",
+            "dnaSeqQC.bwaMem.runBwaMem_bwaRef": null,
             "dnaSeqQC.bwaMem.runBwaMem_jobMemory": null,
-            "dnaSeqQC.bwaMem.runBwaMem_modules": "samtools/1.9 bwa/0.7.12 hg19-bwa-index/0.7.12",
+            "dnaSeqQC.bwaMem.runBwaMem_modules": null,
             "dnaSeqQC.bwaMem.runBwaMem_threads": null,
             "dnaSeqQC.bwaMem.runBwaMem_timeout": null,
             "dnaSeqQC.bwaMem.slicerR1_jobMemory": null,
@@ -676,6 +679,7 @@
                 },
                 "type": "EXTERNAL"
             },
+            "dnaSeqQC.reference": "hg19",
             "dnaSeqQC.outputFileNamePrefix": "dnaSeqQC_test_CRE_custom"
         },
         "description": "dnaSeqQC workflow test",


### PR DESCRIPTION
bamQC call requires intrval information and for TS/EX types we use a number of variant files which are controlled by shesmu functions. THerefore, bamQC will need to keep parametrized using the respective olive. For bwaMem part all assembly-specific code moves inside the workflow.